### PR TITLE
Pull Request to test Actions + Milestone setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 
 This repo shows how to write a GitHub Actions workflow that is triggered when
 the milestone of a pull request changes.
+
+---


### PR DESCRIPTION
This PR exercises the [`check-pr-milestone.yml` workflow](https://github.com/mokagio/github-action-milestone-workflow-example/blob/e65436a60b843a69e2110127554747b941597b20/.github/workflows/check-pr-milestone.yml).

Add or remove a milestone and verify that the workflow run both the `check` step because of the `if` condition filtering for events triggered by PRs. In case of a `demilestoned` event or of a PR created without a milestone, there should also be a comment in the PR from the @github-actions bot made from [the `Dangerfile`](https://github.com/Automattic/peril-settings/blob/35966b3f3b4c40cf6e515437a8c769a8046814b8/org/pr/milestone.ts).

<img width="948" alt="Screen Shot 2020-02-25 at 08 41 26" src="https://user-images.githubusercontent.com/1218433/75193574-a1460980-57aa-11ea-8d82-f94a6b74b028.png">

For example:

- [This](https://github.com/mokagio/github-action-milestone-workflow-example/actions/runs/44536543) is the workflow that run when the PR was created (`pull_request.open`), posting a comment about the missing milestone
- [This](https://github.com/mokagio/github-action-milestone-workflow-example/actions/runs/44537121) is the workflow that run when a milestone was added (`issues.milestoned`),
removing the comment about the missing milestone
- [This](https://github.com/mokagio/github-action-milestone-workflow-example/actions/runs/44537522) is the workflow that run when a milestone was added (`issues.demilestoned`), posting a comment about the missing milestone